### PR TITLE
Added counties view and clickable sidebar

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,32 +1,44 @@
 import React, { useCallback, useState } from 'react';
 import ReactDOM from 'react-dom/client';
+import { CountyData } from './Counties';
 import Map from './Map';
 import NavBar from './Navbar';
 import Sidebar from './Sidebar';
-
-export interface StateData {
-  name: string;
-  description: string;
-}
+import { StateData } from './States';
 
 const App: React.FC = () => {
   const [selectedState, setSelectedState] = useState<StateData | null>(null);
+  const [selectedCounty, setSelectedCounty] = useState<CountyData | null>(null);
 
   const handleStateSelect = useCallback((data: StateData) => {
     setSelectedState(data);
+    setSelectedCounty(null); // Clear county selection when state is selected
+  }, []);
+
+  const handleCountySelect = useCallback((data: CountyData) => {
+    setSelectedCounty(data);
+    setSelectedState(null); // Clear state selection when county is selected
   }, []);
 
   const handleSidebarClose = useCallback(() => {
     setSelectedState(null);
+    setSelectedCounty(null);
   }, []);
 
   return (
     <div>
       <NavBar />
       <div className="flex h-[calc(100vh-64px)]">
-        <Sidebar stateData={selectedState} onClose={handleSidebarClose} />
+        <Sidebar
+          stateData={selectedState}
+          countyData={selectedCounty}
+          onClose={handleSidebarClose}
+        />
         <div className="w-full h-full">
-          <Map onStateSelect={handleStateSelect} />
+          <Map
+            onStateSelect={handleStateSelect}
+            onCountySelect={handleCountySelect}
+          />
         </div>
       </div>
     </div>

--- a/src/components/Counties.tsx
+++ b/src/components/Counties.tsx
@@ -1,0 +1,206 @@
+import * as turf from '@turf/turf';
+import maplibregl from 'maplibre-gl';
+import countyData from '../data/geojson/counties-albers.json';
+
+const COUNTY_LABEL_ID = 'county-labels-layer';
+
+export interface CountyData {
+  name: string;
+  description: string;
+}
+
+let isCountySelected = false;
+
+export function loadCounties(
+  map: maplibregl.Map,
+  onCountySelect?: (data: CountyData) => void,
+) {
+  // Process county names to handle array format
+  (countyData as GeoJSON.FeatureCollection).features.forEach(feature => {
+    if (feature.properties) {
+      const name = feature.properties.coty_name;
+      if (Array.isArray(name)) {
+        feature.properties.coty_name = name[0];
+      }
+    }
+  });
+
+  // Add counties source
+  map.addSource('countiesData', {
+    type: 'geojson',
+    data: countyData as unknown as GeoJSON.FeatureCollection,
+    generateId: true,
+  });
+
+  map.addLayer({
+    id: 'counties-layer',
+    type: 'fill',
+    source: 'countiesData',
+    minzoom: 6,
+    paint: {
+      'fill-color': '#F9D65B',
+      'fill-outline-color': '#1E1E1E',
+      'fill-opacity': [
+        'case',
+        ['boolean', ['feature-state', 'hover'], false],
+        1,
+        0.5,
+      ],
+    },
+  });
+
+  // Generate dynamic centroids
+  const labels = (countyData as GeoJSON.FeatureCollection).features
+    .map(feature => {
+      if (!feature.geometry) {
+        return null;
+      }
+
+      const name = feature.properties?.coty_name;
+      const center = turf.centerOfMass(feature).geometry.coordinates;
+
+      return {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: center,
+        },
+        properties: {
+          name: Array.isArray(name) ? name[0] : name,
+        },
+      };
+    })
+    .filter(Boolean);
+
+  const labelGeoJSON: GeoJSON.FeatureCollection = {
+    type: 'FeatureCollection',
+    features: labels as GeoJSON.Feature[],
+  };
+
+  // Add county labels source and layer
+  if (!map.getSource(COUNTY_LABEL_ID)) {
+    map.addSource(COUNTY_LABEL_ID, {
+      type: 'geojson',
+      data: labelGeoJSON,
+    });
+  }
+
+  if (!map.getLayer(COUNTY_LABEL_ID)) {
+    map.addLayer({
+      id: COUNTY_LABEL_ID,
+      type: 'symbol',
+      source: COUNTY_LABEL_ID,
+      minzoom: 6,
+      layout: {
+        'text-field': ['get', 'name'],
+        'text-size': 9,
+        'text-anchor': 'center',
+      },
+      paint: {
+        'text-color': '#000000',
+      },
+    });
+  }
+
+  let hoveredCountyId: string | number | null = null;
+  const tooltip = new maplibregl.Popup({
+    closeButton: false,
+    closeOnClick: false,
+  });
+
+  // Change cursor on hover
+  map.on('mouseenter', 'counties-layer', () => {
+    map.getCanvas().style.cursor = 'pointer';
+  });
+
+  map.on('mousemove', 'counties-layer', e => {
+    if (e.features && e.features.length > 0) {
+      if (hoveredCountyId !== null) {
+        map.setFeatureState(
+          { source: 'countiesData', id: hoveredCountyId },
+          { hover: false },
+        );
+      }
+
+      hoveredCountyId = e.features[0].id ?? null;
+      map.setFeatureState(
+        { source: 'countiesData', id: hoveredCountyId },
+        { hover: true },
+      );
+
+      const cotyName = e.features[0].properties?.coty_name;
+
+      tooltip.setLngLat(e.lngLat).setHTML(cotyName).addTo(map);
+    }
+  });
+
+  map.on('mouseleave', 'counties-layer', () => {
+    map.getCanvas().style.cursor = '';
+    if (hoveredCountyId !== null) {
+      map.setFeatureState(
+        {
+          source: 'countiesData',
+          id: hoveredCountyId,
+        },
+        { hover: false },
+      );
+    }
+    tooltip.remove();
+    hoveredCountyId = null;
+  });
+
+  // On click, call the passed callback to select a county
+  map.on('click', 'counties-layer', e => {
+    if (e.features && e.features.length > 0 && onCountySelect) {
+      const feature = e.features[0];
+      const countyName = feature.properties?.coty_name;
+
+      const countyData: CountyData = {
+        name: countyName || 'Unknown County',
+        description: `Details about ${countyName || 'Unknown County'}...`,
+      };
+      onCountySelect(countyData);
+      if (!isCountySelected) {
+        zoomToCounty(map, feature);
+        isCountySelected = true;
+      }
+    }
+  });
+}
+
+// Zoom to the selected county, using the county border as the bounding box
+function zoomToCounty(
+  map: maplibregl.Map,
+  feature: maplibregl.MapGeoJSONFeature,
+) {
+  const bounds = [Infinity, Infinity, -Infinity, -Infinity];
+
+  function processCoordinates(coords: number[]) {
+    if (Array.isArray(coords[0])) {
+      coords.forEach(c => processCoordinates(c as unknown as number[]));
+    } else {
+      bounds[0] = Math.min(bounds[0], coords[0]);
+      bounds[1] = Math.min(bounds[1], coords[1]);
+      bounds[2] = Math.max(bounds[2], coords[0]);
+      bounds[3] = Math.max(bounds[3], coords[1]);
+    }
+  }
+
+  if (
+    feature.geometry &&
+    feature.geometry.type !== 'GeometryCollection' &&
+    'coordinates' in feature.geometry
+  ) {
+    processCoordinates(feature.geometry.coordinates as number[]);
+  }
+
+  map.fitBounds(bounds as [number, number, number, number], {
+    padding: 40,
+    maxZoom: 6,
+    duration: 1000,
+  });
+}
+
+export function resetCountySelection() {
+  isCountySelected = false;
+}

--- a/src/components/Counties.tsx
+++ b/src/components/Counties.tsx
@@ -196,7 +196,7 @@ function zoomToCounty(
 
   map.fitBounds(bounds as [number, number, number, number], {
     padding: 40,
-    maxZoom: 6,
+    maxZoom: 10,
     duration: 1000,
   });
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -2,14 +2,16 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import React, { useEffect, useRef, useState } from 'react';
 import '../styles/index.css';
+import { CountyData, loadCounties } from './Counties';
 import Legend from './Legend';
 import { loadStates, StateData } from './States';
 
 interface MapProps {
   onStateSelect?: (data: StateData) => void;
+  onCountySelect?: (data: CountyData) => void;
 }
 
-const Map: React.FC<MapProps> = ({ onStateSelect }) => {
+const Map: React.FC<MapProps> = ({ onStateSelect, onCountySelect }) => {
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const [mapInstance, setMapInstance] = useState<maplibregl.Map | null>(null);
   const STYLE_VERSION = 8; // Required for declaring a style, may change in the future
@@ -37,12 +39,13 @@ const Map: React.FC<MapProps> = ({ onStateSelect }) => {
 
     map.on('load', () => {
       // Load states and pass the onStateSelect callback so a state click will notify the parent.
+      loadCounties(map, onCountySelect);
       loadStates(map, onStateSelect);
       setMapInstance(map);
     });
 
     return () => map.remove();
-  }, [onStateSelect]);
+  }, [onStateSelect, onCountySelect]);
 
   return (
     <div className="relative w-full h-full">

--- a/src/components/MapLabels.tsx
+++ b/src/components/MapLabels.tsx
@@ -74,6 +74,7 @@ export function addLabels(map: maplibregl.Map, geojsonData: FeatureCollection) {
     id: LABEL_LAYER_ID,
     type: 'symbol',
     source: LABEL_LAYER_ID,
+    maxzoom: 6,
     layout: {
       'text-field': ['get', 'name'],
       'text-size': 10,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,12 +15,16 @@ interface SidebarProps {
     name: string;
     description: string;
   };
+  countyData?: {
+    name: string;
+    description: string;
+  };
   onChipSelectionChange?: (chips: ChipData[]) => void;
   onClose?: () => void;
 }
 
 const Sidebar: React.FC<SidebarProps> = props => {
-  const { stateData, onChipSelectionChange, onClose } = props;
+  const { stateData, countyData, onChipSelectionChange, onClose } = props;
 
   const [isVisible, setIsVisible] = useState(false);
   const [chips, setChips] = useState<ChipData[]>([
@@ -36,9 +40,9 @@ const Sidebar: React.FC<SidebarProps> = props => {
   ]);
 
   useEffect(() => {
-    // Show the sidebar if stateData exists; hide otherwise
-    setIsVisible(!!stateData);
-  }, [stateData]);
+    // Show the sidebar if stateData or countyData exists; hide otherwise
+    setIsVisible(!!stateData || !!countyData);
+  }, [stateData, countyData]);
 
   const toggleChip = (id: string) => {
     const updatedChips = chips.map(chip =>
@@ -130,8 +134,28 @@ const Sidebar: React.FC<SidebarProps> = props => {
               ))}
             </div>
           </div>
+        ) : countyData ? (
+          <div>
+            <h2 className="text-xl font-bold mb-2">{countyData.name}</h2>
+            <p>{countyData.description}</p>
+            <div className="mt-4 space-y-4">
+              {mockIncentivesData.incentives.map((incentive: Incentive) => (
+                <IncentiveCard
+                  key={incentive.id}
+                  typeChips={incentive.payment_methods}
+                  headline={incentive.program}
+                  subHeadline={incentive.eligible_geo_group || ''}
+                  body={incentive.short_description.en}
+                  warningChip={
+                    incentive.low_income ? 'Low Income Eligible' : null
+                  }
+                  buttonUrl={incentive.more_info_url?.en || null}
+                />
+              ))}
+            </div>
+          </div>
         ) : (
-          <p>Select a state on the map to view details.</p>
+          <p>Select a state or county on the map to view details.</p>
         )}
       </div>
     </div>

--- a/src/components/States.tsx
+++ b/src/components/States.tsx
@@ -41,6 +41,7 @@ function loadStates(
     id: 'states-layer',
     type: 'fill',
     source: 'statesData',
+    maxzoom: 6,
     paint: {
       'fill-color': '#FCF6E1',
       'fill-outline-color': '#1E1E1E',
@@ -68,6 +69,7 @@ function loadStates(
     id: 'states-coverage-layer',
     type: 'fill',
     source: 'statesData',
+    maxzoom: 6,
     filter: [
       'all',
       ['in', 'ste_name', ...coverageStates],
@@ -99,6 +101,7 @@ function loadStates(
     id: 'states-no-coverage-layer',
     type: 'fill',
     source: 'statesData',
+    maxzoom: 6,
     filter: [
       'all',
       ['in', 'ste_name', ...noCoverageStates],
@@ -125,6 +128,7 @@ function loadStates(
     id: 'states-beta-layer',
     type: 'fill',
     source: 'statesData',
+    maxzoom: 6,
     filter: [
       'all',
       ['in', 'ste_name', ...betaStates],
@@ -189,8 +193,6 @@ function loadStates(
   // On click, call the passed callback to select a state
   map.on('click', 'states-layer', e => {
     if (e.features && e.features.length > 0 && onStateSelect) {
-      console.log('State Name:', e.features[0].properties.name);
-
       const feature = e.features[0];
       const stateName = feature.properties.ste_name;
 


### PR DESCRIPTION
## Description
- Counties are now visible at Zoom level 6
- Counties can click and zoom in, as well as appear on the sidebar
- Different data linkage for sidebar county/state granularity once API implemented

## Related Issue
Closes #63 

## Motivation and Context
This is the next step for our data to successfully be viewed on the map, for more specific data.

## How Has This Been Tested?
- Counties can be viewed on zoom-in
- Clicking on county makes it zoom in, as well as sidebar showing up with the appropriate data/name.

## Screenshots (if appropriate):
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/0e0e7203-62c3-4fbb-a667-9503a4708ced" />
