### PR TITLE
Implemented incentive filters and redesigned UI

### DIFF
--- a/src/components/IncentivesFilter.tsx
+++ b/src/components/IncentivesFilter.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+
+interface IncentivesFilterProps {
+  options: string[];
+  selectedOptions: string[];
+  onChange: (selected: string[]) => void;
+}
+
+const IncentivesFilter: React.FC<IncentivesFilterProps> = ({
+  options,
+  selectedOptions,
+  onChange,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleOption = (option: string) => {
+    if (selectedOptions.includes(option)) {
+      onChange(selectedOptions.filter(item => item !== option));
+    } else {
+      onChange([...selectedOptions, option]);
+    }
+  };
+
+  const toggleDropdown = () => setIsOpen(!isOpen);
+
+  return (
+    <div className="relative w-full">
+      <div
+        onClick={toggleDropdown}
+        className="w-full p-2.5 bg-white border border-gray-300 rounded-md flex justify-between items-center cursor-pointer"
+      >
+        <span className="text-sm text-gray-700">
+          {selectedOptions.length === 0
+            ? 'Select options'
+            : selectedOptions.length === 1
+            ? `1 option selected`
+            : `${selectedOptions.length} options selected`}
+        </span>
+        <svg
+          className={`w-4 h-4 transition-transform ${
+            isOpen ? 'transform rotate-180' : ''
+          }`}
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+
+      {isOpen && (
+        <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
+          {options.length > 0 ? (
+            <div className="p-2">
+              <div className="mb-2 flex justify-between">
+                <button
+                  className="text-xs text-blue-600 hover:text-blue-800"
+                  onClick={() => onChange(options)}
+                >
+                  Select All
+                </button>
+                <button
+                  className="text-xs text-blue-600 hover:text-blue-800"
+                  onClick={() => onChange([])}
+                >
+                  Clear All
+                </button>
+              </div>
+              {options.map(option => (
+                <div
+                  key={option}
+                  className="flex items-center p-2 hover:bg-gray-100 cursor-pointer"
+                  onClick={() => toggleOption(option)}
+                >
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                    checked={selectedOptions.includes(option)}
+                    onChange={() => {}} // Handled by the div onClick
+                    onClick={e => e.stopPropagation()}
+                  />
+                  <label className="ml-2 text-sm text-gray-700 cursor-pointer">
+                    {option.replace(/_/g, ' ')}
+                  </label>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="p-4 text-sm text-gray-500">
+              No options available
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default IncentivesFilter;

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -27,6 +27,63 @@ export const mockIncentivesData: IncentivesResponse = {
       eligible_geo_group: 'ca-energy-smart-homes-territories',
     },
     {
+      id: 'CA-2',
+      eligible_geo_group: 'ca-energy-smart-homes-territories',
+      payment_methods: [PaymentMethod.REBATE],
+      items: [
+        'electric_stove',
+        'other_heat_pump',
+        'non_heat_pump_clothes_dryer',
+        'heat_pump_clothes_dryer',
+      ],
+      program: 'ca_CaliforniaEnergySmartHomes',
+      amount: {
+        type: 'dollar_amount',
+        number: 3750,
+      },
+      owner_status: [OwnerStatus.HOMEOWNER],
+      short_description: {
+        en: '$3,750 rebate for installing heat pump space heating, heat pump water heating, induction cooking, and an electric dryer (must install all).',
+      },
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    },
+    {
+      id: 'CA-3',
+      eligible_geo_group: 'ca-energy-smart-homes-territories',
+      payment_methods: [PaymentMethod.REBATE],
+      items: ['heat_pump_clothes_dryer'],
+      program: 'ca_CaliforniaEnergySmartHomes',
+      amount: {
+        type: 'dollar_amount',
+        number: 250,
+      },
+      owner_status: [OwnerStatus.HOMEOWNER],
+      short_description: {
+        en: '$250 bonus rebate for installing a heat pump dryer when making a whole building electrification upgrade.',
+      },
+      start_date: '2024-01-01',
+      end_date: '2025-12-31',
+    },
+    {
+      id: 'CA-4',
+      eligible_geo_group: 'ca-energy-smart-homes-territories',
+      payment_methods: [PaymentMethod.REBATE],
+      items: ['other'],
+      program: 'ca_CaliforniaEnergySmartHomes',
+      amount: {
+        type: 'dollar_amount',
+        number: 1000,
+        minimum: 1000,
+      },
+      owner_status: [OwnerStatus.HOMEOWNER],
+      short_description: {
+        en: 'Bonus rebate of up to $1,000 for electric infrastructure upgrades (per unit served) when making a whole home electrification alteration.',
+      },
+      start_date: '2024-01-01',
+      end_date: '2025-12-31',
+    },
+    {
       id: 'NY-33',
       program: 'ny-appliance-upgrade-program',
       payment_methods: [PaymentMethod.REBATE],

--- a/test/sidebar.test.tsx
+++ b/test/sidebar.test.tsx
@@ -67,35 +67,12 @@ describe('Sidebar Component', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
-  test('renders chips and toggles their selection state', () => {
-    render(
-      <Sidebar
-        stateData={mockStateData}
-        onChipSelectionChange={mockOnChipSelectionChange}
-      />,
-    );
-    const spanElement = screen.getByText('Incentive 1');
-    const chipButton = spanElement.closest('button');
-
-    if (chipButton) {
-      // Button should be selected
-      expect(chipButton).toHaveClass('bg-[#eed87e]');
-      fireEvent.click(chipButton);
-      expect(mockOnChipSelectionChange).toHaveBeenCalledTimes(1);
-      expect(mockOnChipSelectionChange).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ id: 'chip1', selected: false }),
-        ]),
-      );
-    }
-  });
-
   test('renders incentives when stateData is provided', () => {
     render(<Sidebar stateData={mockStateData} />);
-    // Check that the incentive program title for California is displayed
-    expect(
-      screen.getByText('ca_CaliforniaEnergySmartHomes'),
-    ).toBeInTheDocument();
+    // Use getAllByText instead of getByText to allow multiple occurrences
+    const programElements = screen.getAllByText('ca_CaliforniaEnergySmartHomes');
+    // Check that at least one instance exists
+    expect(programElements.length).toBeGreaterThan(0);
   });
 
   test('displays a placeholder message when no stateData is provided', () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

- Allows a user to filter incentives based on project type
- Currently shows all incentives available for a state. County-specfic filtering will come later
- Only shows incentives with filters that are enabled. If no filters are selected, no incentives will show and a warning will show to select at least one filter for a filter to show
- Made it easy to select/deselect all 
- Redesigned the look of the sidebar to make it easier to see against the incentive cards

## Related Issue

<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

Resolves #7 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This helps users see relevant incentives in a much easier and quicker way.

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- If no tests were run, reply with N/A -->

1. I added more mock data to data.ts so that a state (California) would have multiple incentives, each with different and some with overlapping project types
2. I then selected all filters to ensure that all of CA's incentives showed
3. I then left only a few filters active, and ensured that the incentives still showing each had at least one of the active project types associated
4. I ensured the select all and deselect all buttons worked

## Screenshots (if appropriate):
<img width="1460" alt="Screenshot 2025-04-01 at 1 36 17 AM" src="https://github.com/user-attachments/assets/fe4c8a25-c482-471d-98d1-d2d11b31eb5b" />
