### PR TITLE
Grouped filters by incentive categories

### DIFF
--- a/src/data/incentiveCategories.ts
+++ b/src/data/incentiveCategories.ts
@@ -1,0 +1,60 @@
+// Map from user-friendly categories to the exact API item keys
+export const INCENTIVE_CATEGORIES: Record<string, string[]> = {
+  'Clothes dryer': ['heat_pump_clothes_dryer', 'non_heat_pump_clothes_dryer'],
+  'Cooking stove/range': ['electric_stove'],
+  'Electric transportation': ['ebike', 'electric_vehicle_charger', 'new_electric_vehicle', 'new_plugin_hybrid_vehicle', 'used_electric_vehicle', 'used_plugin_hybrid_vehicle'],
+  'Electrical panel & wiring': ['electric_panel', 'electric_wiring', 'electric_service_upgrades'],
+  'Heating, ventilation & cooling': [
+    'air_to_water_heat_pump',
+    'central_air_conditioner',
+    'ducted_heat_pump',
+    'ductless_heat_pump',
+    'electric_thermal_storage_and_slab',
+    'evaporative_cooler',
+    'geothermal_heating_installation',
+    'smart_thermostat',
+    'whole_house_fan',
+    'integrated_heat_pump_controls',
+    'other_heat_pump'
+  ],
+  'Water heater': ['heat_pump_water_heater', 'non_heat_pump_water_heater', 'solar_water_heater'],
+  'Weatherization & efficiency': [
+    'attic_or_roof_insulation',
+    'basement_insulation',
+    'cool_roof',
+    'crawlspace_insulation',
+    'floor_insulation',
+    'wall_insulation',
+    'other_insulation',
+    'air_sealing',
+    'door_replacement',
+    'duct_replacement',
+    'duct_sealing',
+    'window_replacement',
+    'solar_screen_films',
+    'other_weatherization',
+    'efficiency_rebates',
+    'energy_audit'
+  ],
+  'Battery storage': ['battery_storage_installation'],
+  'Lawn Care': ['electric_outdoor_equipment'],
+  'Solar': ['rooftop_solar_installation']
+};
+
+// Create a reverse mapping to find which category an item belongs to
+export const getIncentiveCategory = (item: string): string | null => {
+  // Exact match is preferred
+  for (const [category, items] of Object.entries(INCENTIVE_CATEGORIES)) {
+    if (items.includes(item)) {
+      return category;
+    }
+  }
+  
+  // If no exact match, return null
+  return null;
+};
+
+// Get all category names
+export const getAllCategoryNames = (): string[] => {
+  return Object.keys(INCENTIVE_CATEGORIES);
+};

--- a/src/data/incentiveCategories.ts
+++ b/src/data/incentiveCategories.ts
@@ -1,10 +1,10 @@
 // Map from user-friendly categories to the exact API item keys
 export const INCENTIVE_CATEGORIES: Record<string, string[]> = {
-  'Clothes dryer': ['heat_pump_clothes_dryer', 'non_heat_pump_clothes_dryer'],
-  'Cooking stove/range': ['electric_stove'],
-  'Electric transportation': ['ebike', 'electric_vehicle_charger', 'new_electric_vehicle', 'new_plugin_hybrid_vehicle', 'used_electric_vehicle', 'used_plugin_hybrid_vehicle'],
-  'Electrical panel & wiring': ['electric_panel', 'electric_wiring', 'electric_service_upgrades'],
-  'Heating, ventilation & cooling': [
+  'Clothes Dryer': ['heat_pump_clothes_dryer', 'non_heat_pump_clothes_dryer'],
+  'Cooking Stove/Range': ['electric_stove'],
+  'Electric Transportation': ['ebike', 'electric_vehicle_charger', 'new_electric_vehicle', 'new_plugin_hybrid_vehicle', 'used_electric_vehicle', 'used_plugin_hybrid_vehicle'],
+  'Electrical Panel & Wiring': ['electric_panel', 'electric_wiring', 'electric_service_upgrades'],
+  'Heating, Ventilation & Cooling': [
     'air_to_water_heat_pump',
     'central_air_conditioner',
     'ducted_heat_pump',
@@ -17,8 +17,8 @@ export const INCENTIVE_CATEGORIES: Record<string, string[]> = {
     'integrated_heat_pump_controls',
     'other_heat_pump'
   ],
-  'Water heater': ['heat_pump_water_heater', 'non_heat_pump_water_heater', 'solar_water_heater'],
-  'Weatherization & efficiency': [
+  'Water Heater': ['heat_pump_water_heater', 'non_heat_pump_water_heater', 'solar_water_heater'],
+  'Weatherization & Efficiency': [
     'attic_or_roof_insulation',
     'basement_insulation',
     'cool_roof',
@@ -36,7 +36,7 @@ export const INCENTIVE_CATEGORIES: Record<string, string[]> = {
     'efficiency_rebates',
     'energy_audit'
   ],
-  'Battery storage': ['battery_storage_installation'],
+  'Battery Storage': ['battery_storage_installation'],
   'Lawn Care': ['electric_outdoor_equipment'],
   'Solar': ['rooftop_solar_installation']
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Instead of showing the raw incentive API cateogies for filtering (such as `heat_pump`), projects and utilities are now nicely grouped together under user-friendly wording, like 'Heat Pumps', 'Clothes Dryer', 'Water Heater', etc. These categories come straight from the current incentives calculator found [here](https://homes.rewiringamerica.org/calculator).

## Related Issue

<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

Resolves #8 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This change makes filtering more user-friendly and easier to understand/filter

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- If no tests were run, reply with N/A -->

N/A

## Screenshots (if appropriate):
<img width="401" alt="Screenshot 2025-04-07 at 1 36 30 PM" src="https://github.com/user-attachments/assets/8b2a9840-4d28-4ff6-bb19-762498832d14" />