### PR TITLE
Added search by county

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -35,7 +35,9 @@ const App: React.FC = () => {
       <NavBar
         map={mapInstance}
         zoomToState={zoomToState}
+        zoomToCounty={zoomToState}
         onStateSelect={handleStateSelect}
+        onCountySelect={handleCountySelect}
       />
       <div className="flex h-[calc(100vh-64px)]">
         <Sidebar

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import ReactDOM from 'react-dom/client';
-import { CountyData } from './Counties';
+import { CountyData, zoomToCounty } from './Counties';
 import Map from './Map';
 import NavBar from './Navbar';
 import Sidebar from './Sidebar';
@@ -35,7 +35,7 @@ const App: React.FC = () => {
       <NavBar
         map={mapInstance}
         zoomToState={zoomToState}
-        zoomToCounty={zoomToState}
+        zoomToCounty={zoomToCounty}
         onStateSelect={handleStateSelect}
         onCountySelect={handleCountySelect}
       />

--- a/src/components/Counties.tsx
+++ b/src/components/Counties.tsx
@@ -179,4 +179,4 @@ function zoomToCounty(
   });
 }
 
-export { loadCounties };
+export { loadCounties, zoomToCounty };

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,8 +3,6 @@ import React, { useState } from 'react';
 import logo from '../assets/logo.png';
 import countyGeojson from '../data/geojson/counties-albers.json';
 import stateGeojson from '../data/geojson/states-albers.json';
-import { CountyData } from './Counties';
-import { StateData } from './States';
 
 interface NavbarProps {
   map: maplibregl.Map;
@@ -16,15 +14,14 @@ interface NavbarProps {
     map: maplibregl.Map,
     feature: maplibregl.MapGeoJSONFeature,
   ) => void;
-  onStateSelect: (data: StateData) => void;
-  onCountySelect: (data: CountyData) => void;
+  onStateSelect: (feature: maplibregl.MapGeoJSONFeature) => void;
+  onCountySelect: (feature: maplibregl.MapGeoJSONFeature) => void;
 }
 
 type SearchOption = {
   label: string;
   type: 'state' | 'county';
   feature?: maplibregl.MapGeoJSONFeature;
-  data: StateData | CountyData;
 };
 
 const Navbar: React.FC<NavbarProps> = ({
@@ -61,10 +58,6 @@ const Navbar: React.FC<NavbarProps> = ({
         label: stateDisplayName,
         type: 'state',
         feature,
-        data: {
-          name: stateDisplayName || 'Unknown State',
-          description: `Details about ${stateDisplayName}...`,
-        } as StateData,
       };
     }),
     ...countiesFiltered.map(feature => {
@@ -80,10 +73,6 @@ const Navbar: React.FC<NavbarProps> = ({
         label: `${countyName}, ${stateName}`,
         type: 'county',
         feature,
-        data: {
-          name: countyName || 'Unknown County',
-          description: `Details about ${countyName}...`,
-        } as CountyData,
       };
     }),
   ];
@@ -108,13 +97,12 @@ const Navbar: React.FC<NavbarProps> = ({
       }
 
       const feature = searchOption.feature;
-      const data = searchOption.data;
 
       if (feature && searchOption.type === 'state') {
-        onStateSelect(data);
+        onStateSelect(feature);
         zoomToState(map, feature);
       } else if (feature && searchOption.type === 'county') {
-        onCountySelect(data);
+        onCountySelect(feature);
         zoomToCounty(map, feature);
       } else {
         console.error(`State/county "${searchTerm}" not found.`);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

<!-- Describe your changes in detail -->
- Added counties to the list of search options
- Searching a county selects and zooms into that county

## Related Issue

<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->
Closes #74 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Allowing users to select a county with the search bar to view incentive information and to navigate to the county is an easier form of navigation for the user. 

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- If no tests were run, reply with N/A -->
Visual testing was used.
- Enter county name in the search bar and submit search. Should zoom to county and select the county in the sidebar.
- Existing search by state functionality should be maintained.

## Screenshots (if appropriate):
Note that the sidebar is not set up to display county data yet
<img width="1710" alt="county search options for California" src="https://github.com/user-attachments/assets/caa89501-672a-4a66-a1fc-848433a55117" />
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/79a037c6-c6b3-48ad-a6fc-1d2c88d351ad" />
