### PR TITLE
Create highlights + refactor state/county data selection

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,25 +1,32 @@
 import React, { useCallback, useState } from 'react';
 import ReactDOM from 'react-dom/client';
-import { CountyData } from './Counties';
 import Map from './Map';
 import NavBar from './Navbar';
 import Sidebar from './Sidebar';
-import { StateData, zoomToState } from './States';
+import { zoomToState } from './States';
 
 const App: React.FC = () => {
-  const [selectedState, setSelectedState] = useState<StateData | null>(null);
-  const [selectedCounty, setSelectedCounty] = useState<CountyData | null>(null);
+  const [selectedState, setSelectedState] =
+    useState<maplibregl.MapGeoJSONFeature | null>(null);
+  const [selectedCounty, setSelectedCounty] =
+    useState<maplibregl.MapGeoJSONFeature | null>(null);
   const [mapInstance, setMapInstance] = useState<maplibregl.Map | null>(null);
 
-  const handleStateSelect = useCallback((data: StateData) => {
-    setSelectedState(data);
-    setSelectedCounty(null); // Clear county selection when state is selected
-  }, []);
+  const handleStateSelect = useCallback(
+    (feature: maplibregl.MapGeoJSONFeature) => {
+      setSelectedState(feature);
+      setSelectedCounty(null); // Clear county selection when state is selected
+    },
+    [],
+  );
 
-  const handleCountySelect = useCallback((data: CountyData) => {
-    setSelectedCounty(data);
-    setSelectedState(null); // Clear state selection when county is selected
-  }, []);
+  const handleCountySelect = useCallback(
+    (feature: maplibregl.MapGeoJSONFeature) => {
+      setSelectedCounty(feature);
+      setSelectedState(null); // Clear state selection when county is selected
+    },
+    [],
+  );
 
   const handleSidebarClose = useCallback(() => {
     setSelectedState(null);
@@ -35,12 +42,11 @@ const App: React.FC = () => {
       <NavBar
         map={mapInstance}
         zoomToState={zoomToState}
-        onStateSelect={handleStateSelect}
+        onFeatureSelect={handleStateSelect}
       />
       <div className="flex h-[calc(100vh-64px)]">
         <Sidebar
-          stateData={selectedState}
-          countyData={selectedCounty}
+          selectedFeature={selectedState || selectedCounty}
           onClose={handleSidebarClose}
         />
         <div className="w-full h-full">

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -49,6 +49,8 @@ const App: React.FC = () => {
             onCountySelect={handleCountySelect}
             mapInstance={mapInstance}
             onMapSet={handleSetMapInstance}
+            selectedState={selectedState}
+            selectedCounty={selectedCounty}
           />
         </div>
       </div>

--- a/src/components/Counties.tsx
+++ b/src/components/Counties.tsx
@@ -4,21 +4,20 @@ import countyData from '../data/geojson/counties-albers.json';
 
 const COUNTY_LABEL_ID = 'county-labels-layer';
 
-export interface CountyData {
-  name: string;
-  description: string;
-}
-
 function loadCounties(
   map: maplibregl.Map,
-  onCountySelect?: (data: CountyData) => void,
+  onCountySelect?: (feature: maplibregl.MapGeoJSONFeature) => void,
 ) {
   // Process county names to handle array format
   (countyData as GeoJSON.FeatureCollection).features.forEach(feature => {
     if (feature.properties) {
       const name = feature.properties.coty_name;
+      const state = feature.properties.ste_name;
       if (Array.isArray(name)) {
         feature.properties.coty_name = name[0];
+      }
+      if (Array.isArray(state)) {
+        feature.properties.ste_name = state[0];
       }
     }
   });
@@ -151,13 +150,7 @@ function loadCounties(
   map.on('click', 'counties-layer', e => {
     if (e.features && e.features.length > 0 && onCountySelect) {
       const feature = e.features[0];
-      const countyName = feature.properties?.coty_name;
-
-      const countyData: CountyData = {
-        name: countyName || 'Unknown County',
-        description: `Details about ${countyName || 'Unknown County'}...`,
-      };
-      onCountySelect(countyData);
+      onCountySelect(feature);
       setTimeout(() => {
         zoomToCounty(map, feature);
       }, 10);

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -2,18 +2,18 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import React, { useEffect, useRef } from 'react';
 import '../styles/index.css';
-import { CountyData, loadCounties } from './Counties';
+import { loadCounties } from './Counties';
 import Legend from './Legend';
 import MapHighlights from './MapHighlights';
-import { loadStates, StateData } from './States';
+import { loadStates } from './States';
 
 interface MapProps {
-  onStateSelect?: (data: StateData) => void;
-  onCountySelect?: (data: CountyData) => void;
+  onStateSelect?: (feature: maplibregl.MapGeoJSONFeature) => void;
+  onCountySelect?: (feature: maplibregl.MapGeoJSONFeature) => void;
   mapInstance: maplibregl.Map | null;
   onMapSet: React.Dispatch<React.SetStateAction<maplibregl.Map | null>>;
-  selectedState: StateData | null;
-  selectedCounty: CountyData | null;
+  selectedState: maplibregl.MapGeoJSONFeature | null;
+  selectedCounty: maplibregl.MapGeoJSONFeature | null;
 }
 
 const Map: React.FC<MapProps> = ({
@@ -64,8 +64,8 @@ const Map: React.FC<MapProps> = ({
       <Legend map={mapInstance} />
       <MapHighlights
         map={mapInstance}
-        selectedState={selectedState?.name || null}
-        selectedCounty={selectedCounty?.name || null}
+        selectedState={selectedState}
+        selectedCounty={selectedCounty}
       />
     </div>
   );

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef } from 'react';
 import '../styles/index.css';
 import { CountyData, loadCounties } from './Counties';
 import Legend from './Legend';
+import MapHighlights from './MapHighlights';
 import { loadStates, StateData } from './States';
 
 interface MapProps {
@@ -11,6 +12,8 @@ interface MapProps {
   onCountySelect?: (data: CountyData) => void;
   mapInstance: maplibregl.Map | null;
   onMapSet: React.Dispatch<React.SetStateAction<maplibregl.Map | null>>;
+  selectedState: StateData | null;
+  selectedCounty: CountyData | null;
 }
 
 const Map: React.FC<MapProps> = ({
@@ -18,6 +21,8 @@ const Map: React.FC<MapProps> = ({
   onCountySelect,
   mapInstance,
   onMapSet,
+  selectedState,
+  selectedCounty,
 }) => {
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const STYLE_VERSION = 8; // Required for declaring a style, may change in the future
@@ -57,6 +62,11 @@ const Map: React.FC<MapProps> = ({
     <div className="relative w-full h-full">
       <div ref={mapContainer} className="absolute inset-0 w-full h-full" />
       <Legend map={mapInstance} />
+      <MapHighlights
+        map={mapInstance}
+        selectedState={selectedState?.name || null}
+        selectedCounty={selectedCounty?.name || null}
+      />
     </div>
   );
 };

--- a/src/components/MapHighlights.tsx
+++ b/src/components/MapHighlights.tsx
@@ -3,8 +3,8 @@ import { useEffect } from 'react';
 
 interface MapHighlightsProps {
   map: maplibregl.Map | null;
-  selectedState: string | null;
-  selectedCounty: string | null;
+  selectedState: maplibregl.MapGeoJSONFeature | null;
+  selectedCounty: maplibregl.MapGeoJSONFeature | null;
 }
 
 const MapHighlights: React.FC<MapHighlightsProps> = ({
@@ -13,9 +13,10 @@ const MapHighlights: React.FC<MapHighlightsProps> = ({
   selectedCounty,
 }) => {
   useEffect(() => {
-    if (!map) {return;}
+    if (!map) {
+      return;
+    }
 
-    // Remove existing highlight layers if they exist
     if (map.getLayer('selected-state-highlight')) {
       map.removeLayer('selected-state-highlight');
     }
@@ -29,7 +30,7 @@ const MapHighlights: React.FC<MapHighlightsProps> = ({
         id: 'selected-state-highlight',
         type: 'line',
         source: 'statesData',
-        filter: ['==', 'ste_name', selectedState],
+        filter: ['==', 'ste_name', selectedState.properties?.ste_name],
         paint: {
           'line-color': '#3d0db4',
           'line-width': 3,
@@ -44,7 +45,11 @@ const MapHighlights: React.FC<MapHighlightsProps> = ({
         id: 'selected-county-highlight',
         type: 'line',
         source: 'countiesData',
-        filter: ['==', 'coty_name', selectedCounty],
+        filter: [
+          'all',
+          ['==', 'coty_name', selectedCounty.properties?.coty_name],
+          ['==', 'ste_name', selectedCounty.properties?.ste_name],
+        ],
         paint: {
           'line-color': '#3d0db4',
           'line-width': 3,
@@ -53,7 +58,6 @@ const MapHighlights: React.FC<MapHighlightsProps> = ({
       });
     }
 
-    // Cleanup function
     return () => {
       if (map.getLayer('selected-state-highlight')) {
         map.removeLayer('selected-state-highlight');

--- a/src/components/MapHighlights.tsx
+++ b/src/components/MapHighlights.tsx
@@ -1,0 +1,70 @@
+import maplibregl from 'maplibre-gl';
+import { useEffect } from 'react';
+
+interface MapHighlightsProps {
+  map: maplibregl.Map | null;
+  selectedState: string | null;
+  selectedCounty: string | null;
+}
+
+const MapHighlights: React.FC<MapHighlightsProps> = ({
+  map,
+  selectedState,
+  selectedCounty,
+}) => {
+  useEffect(() => {
+    if (!map) {return;}
+
+    // Remove existing highlight layers if they exist
+    if (map.getLayer('selected-state-highlight')) {
+      map.removeLayer('selected-state-highlight');
+    }
+    if (map.getLayer('selected-county-highlight')) {
+      map.removeLayer('selected-county-highlight');
+    }
+
+    // Add state highlight if a state is selected
+    if (selectedState) {
+      map.addLayer({
+        id: 'selected-state-highlight',
+        type: 'line',
+        source: 'statesData',
+        filter: ['==', 'ste_name', selectedState],
+        paint: {
+          'line-color': '#3d0db4',
+          'line-width': 3,
+          'line-opacity': 1,
+        },
+      });
+    }
+
+    // Add county highlight if a county is selected
+    if (selectedCounty) {
+      map.addLayer({
+        id: 'selected-county-highlight',
+        type: 'line',
+        source: 'countiesData',
+        filter: ['==', 'coty_name', selectedCounty],
+        paint: {
+          'line-color': '#3d0db4',
+          'line-width': 3,
+          'line-opacity': 1,
+        },
+      });
+    }
+
+    // Cleanup function
+    return () => {
+      if (map.getLayer('selected-state-highlight')) {
+        map.removeLayer('selected-state-highlight');
+      }
+      if (map.getLayer('selected-county-highlight')) {
+        map.removeLayer('selected-county-highlight');
+      }
+    };
+  }, [map, selectedState, selectedCounty]);
+
+  return null;
+};
+
+export default MapHighlights;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import logo from '../assets/logo.png';
 import geojsonData from '../data/geojson/states-albers.json';
 import { US_STATE_NAMES } from '../data/states';
-import { StateData } from './States';
 
 interface NavbarProps {
   map: maplibregl.Map;
@@ -11,10 +10,14 @@ interface NavbarProps {
     map: maplibregl.Map,
     feature: maplibregl.MapGeoJSONFeature,
   ) => void;
-  onStateSelect: (data: StateData) => void;
+  onFeatureSelect: (feature: maplibregl.MapGeoJSONFeature) => void;
 }
 
-const Navbar: React.FC<NavbarProps> = ({ map, zoomToState, onStateSelect }) => {
+const Navbar: React.FC<NavbarProps> = ({
+  map,
+  zoomToState,
+  onFeatureSelect,
+}) => {
   const [searchTerm, setSearchTerm] = useState('');
 
   const handleSearchChange = (
@@ -38,14 +41,9 @@ const Navbar: React.FC<NavbarProps> = ({ map, zoomToState, onStateSelect }) => {
         return steName === stateName;
       });
 
-      const stateData: StateData = {
-        name: stateName,
-        description: `Details about ${stateName}...`,
-      };
-      onStateSelect(stateData);
-
       if (feature) {
-        zoomToState(map, feature);
+        onFeatureSelect(feature as maplibregl.MapGeoJSONFeature);
+        zoomToState(map, feature as maplibregl.MapGeoJSONFeature);
       } else {
         console.error(`State "${searchTerm}" not found.`);
       }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import { IncentiveCard } from './incentive-card';
 import IncentivesFilter from './IncentivesFilter';
 
 interface SidebarProps {
-  selectedFeature: maplibregl.MapGeoJSONFeature | null;
+  selectedFeature?: maplibregl.MapGeoJSONFeature | null;
   onClose?: () => void;
 }
 
@@ -138,7 +138,7 @@ const Sidebar: React.FC<SidebarProps> = props => {
         {name ? (
           <div>
             <h2 className="text-xl font-bold mb-2">{name}</h2>
-            <p>Details about {name}...</p>
+            <p>Details about {name}</p>
             <div className="mt-4 space-y-4">
               {filteredIncentives.length > 0 ? (
                 filteredIncentives.map((incentive: Incentive) => (

--- a/src/components/States.tsx
+++ b/src/components/States.tsx
@@ -5,19 +5,16 @@ import geojsonData from '../data/geojson/states-albers.json';
 import { BETA_STATES, LAUNCHED_STATES, STATES_PLUS_DC } from '../data/states';
 import { addLabels } from './MapLabels';
 
-export interface StateData {
-  name: string;
-  description: string;
-}
-
 function loadStates(
   map: maplibregl.Map,
-  onStateSelect?: (data: StateData) => void,
+  onStateSelect?: (feature: maplibregl.MapGeoJSONFeature) => void,
 ) {
-  geojsonData.features.forEach(feature => {
-    const name = feature.properties?.ste_name;
-    if (Array.isArray(name)) {
-      feature.properties.ste_name = name[0];
+  (geojsonData as GeoJSON.FeatureCollection).features.forEach(feature => {
+    if (feature.properties) {
+      const name = feature.properties.ste_name;
+      if (Array.isArray(name)) {
+        feature.properties.ste_name = name[0];
+      }
     }
   });
 
@@ -193,15 +190,7 @@ function loadStates(
   map.on('click', 'states-layer', e => {
     if (e.features && e.features.length > 0 && onStateSelect) {
       const feature = e.features[0];
-      const stateName = feature.properties.ste_name;
-
-      const stateData: StateData = {
-        name: stateName,
-        description: `Details about ${stateName}...`,
-      };
-      onStateSelect(stateData);
-
-      // Delay the flyTo method to ensure the sidebar is visible
+      onStateSelect(feature);
       setTimeout(() => {
         zoomToState(map, feature);
       }, 10);

--- a/test/sidebar.test.tsx
+++ b/test/sidebar.test.tsx
@@ -36,11 +36,28 @@ import { OwnerStatus, PaymentMethod } from '../src/mocks/types';
 
 describe('Sidebar Component', () => {
   const mockStateData = {
-    name: 'California',
-    description: 'Details about California',
-  };
+    type: 'Feature',
+    properties: {
+      geo_point_2d: {
+        lon: -119.61060994717245,
+        lat: 37.246338610069266
+      },
+      year: "2023",
+      ste_code: ["06"],
+      ste_name: ["California"],
+      ste_area_code: "USA",
+      ste_type: "state",
+      ste_name_long: null,
+      ste_fp_code: null,
+      ste_gnis_code: "01779778"
+    },
+    geometry: null,
+    _geometry: null,
+    id: 0,
+    _vectorTileFeature: null,
+    toJSON: () => ({})
+  } as unknown as maplibregl.MapGeoJSONFeature;
 
-  const mockOnChipSelectionChange = vi.fn();
   const mockOnClose = vi.fn();
 
   beforeEach(() => {
@@ -55,20 +72,20 @@ describe('Sidebar Component', () => {
   });
 
   test('renders the sidebar when stateData is provided', () => {
-    render(<Sidebar stateData={mockStateData} />);
+    render(<Sidebar selectedFeature={mockStateData} />);
     expect(screen.getByText('California')).toBeInTheDocument();
     expect(screen.getByText('Details about California')).toBeInTheDocument();
   });
 
   test('calls onClose when the close button is clicked', () => {
-    render(<Sidebar stateData={mockStateData} onClose={mockOnClose} />);
+    render(<Sidebar selectedFeature={mockStateData} onClose={mockOnClose} />);
     const closeButton = screen.getByRole('button', { name: /close sidebar/i });
     fireEvent.click(closeButton);
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
-  test('renders incentives when stateData is provided', () => {
-    render(<Sidebar stateData={mockStateData} />);
+  test('renders incentives when feature is provided', () => {
+    render(<Sidebar selectedFeature={mockStateData} />);
     // Use getAllByText instead of getByText to allow multiple occurrences
     const programElements = screen.getAllByText('ca_CaliforniaEnergySmartHomes');
     // Check that at least one instance exists

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,9 @@
         "strict": true
       }
     ],
-    "types": ["node", "react", "react-dom", "@testing-library/jest-dom"]
+    "types": ["node", "react", "react-dom", "@testing-library/jest-dom"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"],
   "exclude": [],


### PR DESCRIPTION
## Description
- Changes how selection is handled in Navbar, Sidebar, and Highlights
- Removes StateData and CountyData and replaces them with MapLibreGL's GeoJSON feature.
- Added highlights to selected state or county

## Related Issue
Closes #76 
Closes #77

## Motivation and Context
It was hard to view counties and states with all of the counties and states being tightly packed together. This ensures visibility for selected features, while refactoring selected features for better codebase maintenance.

## How Has This Been Tested?
Selected counties and states, while zooming in and out to different views to ensure highlights stay. Made sure highlights got removed when deselected. Search bar and sidebar still work.

## Screenshots (if appropriate):
<img width="1441" alt="image" src="https://github.com/user-attachments/assets/d584fe7a-1492-4e35-af78-de2ba0d00695" />
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/4a3f055c-944a-4cef-b5db-9c21ad4db575" />
