### PR TITLE
Removes state and county name tooltip upon hover

### DIFF
--- a/src/components/Counties.tsx
+++ b/src/components/Counties.tsx
@@ -100,10 +100,6 @@ function loadCounties(
   }
 
   let hoveredCountyId: string | number | null = null;
-  const tooltip = new maplibregl.Popup({
-    closeButton: false,
-    closeOnClick: false,
-  });
 
   // Change cursor on hover
   map.on('mouseenter', 'counties-layer', () => {
@@ -124,10 +120,6 @@ function loadCounties(
         { source: 'countiesData', id: hoveredCountyId },
         { hover: true },
       );
-
-      const cotyName = e.features[0].properties?.coty_name;
-
-      tooltip.setLngLat(e.lngLat).setHTML(cotyName).addTo(map);
     }
   });
 
@@ -142,7 +134,6 @@ function loadCounties(
         { hover: false },
       );
     }
-    tooltip.remove();
     hoveredCountyId = null;
   });
 

--- a/src/components/States.tsx
+++ b/src/components/States.tsx
@@ -19,10 +19,6 @@ function loadStates(
   });
 
   let hoveredStateId: string | number | null = null;
-  const tooltip = new maplibregl.Popup({
-    closeButton: false,
-    closeOnClick: false,
-  });
 
   map.addSource('statesData', {
     type: 'geojson',
@@ -149,7 +145,7 @@ function loadStates(
     map.getCanvas().style.cursor = 'pointer';
   });
 
-  // Set hover state and show tooltip
+  // Set hover state
   map.on('mousemove', 'states-layer', e => {
     if (e.features && e.features.length > 0) {
       if (hoveredStateId !== null) {
@@ -163,14 +159,10 @@ function loadStates(
         { source: 'statesData', id: hoveredStateId },
         { hover: true },
       );
-
-      const steName = e.features[0].properties.ste_name;
-
-      tooltip.setLngLat(e.lngLat).setHTML(steName).addTo(map);
     }
   });
 
-  // Remove hover state and tooltip when leaving
+  // Remove hover state when leaving
   map.on('mouseleave', 'states-layer', () => {
     map.getCanvas().style.cursor = '';
     if (hoveredStateId !== null) {
@@ -182,7 +174,6 @@ function loadStates(
         { hover: false },
       );
     }
-    tooltip.remove();
     hoveredStateId = null;
   });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Removes state and county name tooltip upon hover. This was a feature that once was necessary, but is now unessecary since the map itself displays the county and state names.

## Related Issue

<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here: -->

Resolves #82 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This removes an unnecessary feature, helping keep the codebase free of bloat. 

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
<!-- If no tests were run, reply with N/A -->

- Manually hovered and clicked over states and counties to ensure that no tooltip showed, as well as to make sure no bugs occurred. 

## Screenshots (if appropriate):

N/A
