### PR TITLE
Restructured zoom levels and buttons

### DIFF
--- a/src/components/Counties.tsx
+++ b/src/components/Counties.tsx
@@ -7,7 +7,6 @@ const COUNTY_LABEL_ID = 'county-labels-layer';
 function loadCounties(
   map: maplibregl.Map,
   onCountySelect?: (feature: maplibregl.MapGeoJSONFeature) => void,
-  selectedFeature?: maplibregl.MapGeoJSONFeature | null,
 ) {
   // Process county names to handle array format
   (countyData as GeoJSON.FeatureCollection).features.forEach(feature => {
@@ -35,12 +34,6 @@ function loadCounties(
     type: 'fill',
     source: 'countiesData',
     minzoom: 6,
-    filter: selectedFeature
-      ? [
-          'all',
-          ['==', ['get', 'ste_name'], selectedFeature.properties?.ste_name],
-        ]
-      : ['all'],
     paint: {
       'fill-color': '#F9D65B',
       'fill-outline-color': '#1E1E1E',
@@ -61,6 +54,7 @@ function loadCounties(
       }
 
       const name = feature.properties?.coty_name;
+      const state = feature.properties?.ste_name;
       const center = turf.centerOfMass(feature).geometry.coordinates;
 
       return {
@@ -70,7 +64,8 @@ function loadCounties(
           coordinates: center,
         },
         properties: {
-          name: Array.isArray(name) ? name[0] : name,
+          coty_name: Array.isArray(name) ? name[0] : name,
+          ste_name: Array.isArray(state) ? state[0] : state,
         },
       };
     })
@@ -96,7 +91,7 @@ function loadCounties(
       source: COUNTY_LABEL_ID,
       minzoom: 6,
       layout: {
-        'text-field': ['get', 'name'],
+        'text-field': ['get', 'coty_name'],
         'text-size': 9,
         'text-anchor': 'center',
       },

--- a/src/components/Counties.tsx
+++ b/src/components/Counties.tsx
@@ -7,6 +7,7 @@ const COUNTY_LABEL_ID = 'county-labels-layer';
 function loadCounties(
   map: maplibregl.Map,
   onCountySelect?: (feature: maplibregl.MapGeoJSONFeature) => void,
+  selectedFeature?: maplibregl.MapGeoJSONFeature | null,
 ) {
   // Process county names to handle array format
   (countyData as GeoJSON.FeatureCollection).features.forEach(feature => {
@@ -34,6 +35,12 @@ function loadCounties(
     type: 'fill',
     source: 'countiesData',
     minzoom: 6,
+    filter: selectedFeature
+      ? [
+          'all',
+          ['==', ['get', 'ste_name'], selectedFeature.properties?.ste_name],
+        ]
+      : ['all'],
     paint: {
       'fill-color': '#F9D65B',
       'fill-outline-color': '#1E1E1E',

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -44,8 +44,8 @@ const Map: React.FC<MapProps> = ({
       center: [0, 0],
       zoom: 4.2,
       maxBounds: [
-        [-30, -15], // Southwest corner, Mainland USA
-        [30, 15], // Northeast corner, Mainland USA
+        [-30, -20], // Southwest corner, Mainland USA
+        [30, 20], // Northeast corner, Mainland USA
       ],
       interactive: true,
       dragPan: true,
@@ -239,13 +239,13 @@ const Map: React.FC<MapProps> = ({
         zoom: targetZoom,
         essential: true,
       });
-    }, 10);
+    }, 30);
   };
 
   return (
     <div className="relative w-full h-full">
       <div ref={mapContainer} className="absolute inset-0 w-full h-full" />
-      <ZoomControls onZoomOut={handleZoomOut} />
+      {currentZoom > 4.2 && <ZoomControls onZoomOut={handleZoomOut} />}
       <Legend map={mapInstance} />
       <MapHighlights
         map={mapInstance}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -114,7 +114,9 @@ const Map: React.FC<MapProps> = ({
   const removeSelectionFilters = (
     filter: maplibregl.FilterSpecification | void,
   ): maplibregl.FilterSpecification | null => {
-    if (!filter) {return null;}
+    if (!filter) {
+      return null;
+    }
     const isSelectionFilter = (f: maplibregl.FilterSpecification) => {
       return (
         Array.isArray(f) &&
@@ -143,7 +145,9 @@ const Map: React.FC<MapProps> = ({
   };
 
   useEffect(() => {
-    if (!mapInstance) {return;}
+    if (!mapInstance) {
+      return;
+    }
 
     const currentStateName =
       selectedState?.properties?.ste_name ||
@@ -195,7 +199,9 @@ const Map: React.FC<MapProps> = ({
   }, [mapInstance, selectedState, selectedCounty]);
 
   const handleZoomOut = () => {
-    if (!mapInstance) {return;}
+    if (!mapInstance) {
+      return;
+    }
 
     let targetZoom = 4.2; // Default to national view
     if (currentZoom >= 8) {

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,15 +1,16 @@
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import '../styles/index.css';
 import { loadCounties } from './Counties';
 import Legend from './Legend';
 import MapHighlights from './MapHighlights';
-import { loadStates } from './States';
+import { loadStates, zoomToState } from './States';
+import ZoomControls from './ZoomControls';
 
 interface MapProps {
-  onStateSelect?: (feature: maplibregl.MapGeoJSONFeature) => void;
-  onCountySelect?: (feature: maplibregl.MapGeoJSONFeature) => void;
+  onStateSelect: (feature: maplibregl.MapGeoJSONFeature | null) => void;
+  onCountySelect: (feature: maplibregl.MapGeoJSONFeature | null) => void;
   mapInstance: maplibregl.Map | null;
   onMapSet: React.Dispatch<React.SetStateAction<maplibregl.Map | null>>;
   selectedState: maplibregl.MapGeoJSONFeature | null;
@@ -26,41 +27,95 @@ const Map: React.FC<MapProps> = ({
 }) => {
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const STYLE_VERSION = 8; // Required for declaring a style, may change in the future
+  const [currentZoom, setCurrentZoom] = useState(4.2);
 
   useEffect(() => {
     if (!mapContainer.current) {
       return;
     }
-    const API_KEY = process.env.MAPTILER_API_KEY;
     const map = new maplibregl.Map({
       container: mapContainer.current,
       style: {
         version: STYLE_VERSION,
         sources: {},
         layers: [],
-        glyphs: `https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=${API_KEY}`,
+        glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
       },
       center: [0, 0],
       zoom: 4.2,
       maxBounds: [
-        [-25, -15], // Southwest corner, Mainland USA
-        [25, 15], // Northeast corner, Mainland USA
+        [-30, -15], // Southwest corner, Mainland USA
+        [30, 15], // Northeast corner, Mainland USA
       ],
+      interactive: true,
+      dragPan: true,
+      dragRotate: false,
+      scrollZoom: false,
+      doubleClickZoom: false,
+      touchZoomRotate: false,
+      boxZoom: false,
     });
 
     map.on('load', () => {
       // Load states and pass the onStateSelect callback so a state click will notify the parent.
-      loadCounties(map, onCountySelect);
-      loadStates(map, onStateSelect);
+      loadCounties(map, onCountySelect, selectedState || selectedCounty);
+      loadStates(map, onStateSelect, selectedState || selectedCounty);
       onMapSet(map);
+    });
+
+    map.on('zoomend', () => {
+      setCurrentZoom(map.getZoom());
     });
 
     return () => map.remove();
   }, [onStateSelect, onCountySelect, onMapSet]);
 
+  const handleZoomOut = () => {
+    if (!mapInstance) {return;}
+
+    let targetZoom = 4.2; // Default to national view
+    if (currentZoom >= 8) {
+      targetZoom = 6; // County -> State
+
+      if (selectedCounty) {
+        const stateName = selectedCounty.properties?.ste_name;
+        if (stateName) {
+          const statesSource = mapInstance.getSource('statesData');
+          if (statesSource && statesSource.type === 'geojson') {
+            const statesData = statesSource.serialize().data;
+            const stateFeature = statesData.features.find(
+              (feature: maplibregl.MapGeoJSONFeature) =>
+                feature.properties?.ste_name === stateName,
+            );
+            if (stateFeature) {
+              onStateSelect(stateFeature);
+              setTimeout(() => {
+                zoomToState(mapInstance, stateFeature);
+              }, 10);
+              return;
+            }
+          }
+        }
+      }
+    } else if (currentZoom >= 6) {
+      targetZoom = 4.2;
+      onStateSelect(null);
+      onCountySelect(null);
+    }
+
+    setTimeout(() => {
+      mapInstance.flyTo({
+        ...(targetZoom === 4.2 ? { center: [0, 0] } : {}),
+        zoom: targetZoom,
+        essential: true,
+      });
+    }, 10);
+  };
+
   return (
     <div className="relative w-full h-full">
       <div ref={mapContainer} className="absolute inset-0 w-full h-full" />
+      <ZoomControls onZoomOut={handleZoomOut} />
       <Legend map={mapInstance} />
       <MapHighlights
         map={mapInstance}

--- a/src/components/MapLabels.tsx
+++ b/src/components/MapLabels.tsx
@@ -60,7 +60,7 @@ export function addLabels(map: maplibregl.Map, geojsonData: FeatureCollection) {
         coordinates: label.coordinates,
       },
       properties: {
-        name: label.name,
+        ste_name: label.name,
       },
     })),
   };
@@ -74,9 +74,8 @@ export function addLabels(map: maplibregl.Map, geojsonData: FeatureCollection) {
     id: LABEL_LAYER_ID,
     type: 'symbol',
     source: LABEL_LAYER_ID,
-    maxzoom: 6,
     layout: {
-      'text-field': ['get', 'name'],
+      'text-field': ['get', 'ste_name'],
       'text-size': 10,
       'text-anchor': 'center',
     },

--- a/src/components/MapLabels.tsx
+++ b/src/components/MapLabels.tsx
@@ -2,7 +2,7 @@ import * as turf from '@turf/turf';
 import { FeatureCollection } from 'geojson';
 import maplibregl from 'maplibre-gl';
 
-const LABEL_LAYER_ID = 'dynamic-labels-layer';
+const LABEL_LAYER_ID = 'state-labels-layer';
 
 interface LabelData {
   name: string;

--- a/src/components/States.tsx
+++ b/src/components/States.tsx
@@ -8,7 +8,6 @@ import { addLabels } from './MapLabels';
 function loadStates(
   map: maplibregl.Map,
   onStateSelect?: (feature: maplibregl.MapGeoJSONFeature) => void,
-  selectedFeature?: maplibregl.MapGeoJSONFeature | null,
 ) {
   (geojsonData as GeoJSON.FeatureCollection).features.forEach(feature => {
     if (feature.properties) {
@@ -34,13 +33,6 @@ function loadStates(
     id: 'states-layer',
     type: 'fill',
     source: 'statesData',
-    maxzoom: 6,
-    filter: selectedFeature
-      ? [
-          'all',
-          ['!=', ['get', 'ste_name'], selectedFeature.properties?.ste_name],
-        ]
-      : ['all'],
     paint: {
       'fill-color': '#FCF6E1',
       'fill-outline-color': '#1E1E1E',
@@ -68,10 +60,9 @@ function loadStates(
     id: 'states-coverage-layer',
     type: 'fill',
     source: 'statesData',
-    maxzoom: 6,
     filter: [
       'all',
-      ['in', 'ste_name', ...coverageStates],
+      ['in', ['get', 'ste_name'], ['literal', coverageStates]],
     ],
     paint: {
       'fill-color': '#F9D65B',
@@ -100,10 +91,9 @@ function loadStates(
     id: 'states-no-coverage-layer',
     type: 'fill',
     source: 'statesData',
-    maxzoom: 6,
     filter: [
       'all',
-      ['in', 'ste_name', ...noCoverageStates],
+      ['in', ['get', 'ste_name'], ['literal', noCoverageStates]],
     ],
     paint: {
       'fill-color': '#6E33CF',
@@ -127,10 +117,10 @@ function loadStates(
     id: 'states-beta-layer',
     type: 'fill',
     source: 'statesData',
-    maxzoom: 6,
+    //maxzoom: 6,
     filter: [
       'all',
-      ['in', 'ste_name', ...betaStates],
+      ['in', ['get', 'ste_name'], ['literal', betaStates]],
     ],
     paint: {
       'fill-color': '#71C4CB',

--- a/src/components/States.tsx
+++ b/src/components/States.tsx
@@ -8,6 +8,7 @@ import { addLabels } from './MapLabels';
 function loadStates(
   map: maplibregl.Map,
   onStateSelect?: (feature: maplibregl.MapGeoJSONFeature) => void,
+  selectedFeature?: maplibregl.MapGeoJSONFeature | null,
 ) {
   (geojsonData as GeoJSON.FeatureCollection).features.forEach(feature => {
     if (feature.properties) {
@@ -34,6 +35,12 @@ function loadStates(
     type: 'fill',
     source: 'statesData',
     maxzoom: 6,
+    filter: selectedFeature
+      ? [
+          'all',
+          ['!=', ['get', 'ste_name'], selectedFeature.properties?.ste_name],
+        ]
+      : ['all'],
     paint: {
       'fill-color': '#FCF6E1',
       'fill-outline-color': '#1E1E1E',

--- a/src/components/ZoomControls.tsx
+++ b/src/components/ZoomControls.tsx
@@ -1,6 +1,6 @@
 import { IconButton } from '@mui/material';
 import { FC } from 'react';
-import { UpRightArrow } from './icons';
+import { MagnifyingGlassMinus } from './icons';
 
 interface ZoomControlsProps {
   onZoomOut: () => void;
@@ -15,7 +15,7 @@ const ZoomControls: FC<ZoomControlsProps> = ({ onZoomOut }) => {
           className="hover:bg-gray-100"
           aria-label="zoom out"
         >
-          <UpRightArrow w={24} h={24} />
+          <MagnifyingGlassMinus w={24} h={24} />
         </IconButton>
       </div>
     </div>

--- a/src/components/ZoomControls.tsx
+++ b/src/components/ZoomControls.tsx
@@ -1,0 +1,25 @@
+import { IconButton } from '@mui/material';
+import { FC } from 'react';
+import { UpRightArrow } from './icons';
+
+interface ZoomControlsProps {
+  onZoomOut: () => void;
+}
+
+const ZoomControls: FC<ZoomControlsProps> = ({ onZoomOut }) => {
+  return (
+    <div className="absolute top-4 left-4 z-10">
+      <div className="bg-white rounded-lg shadow-lg p-2">
+        <IconButton
+          onClick={onZoomOut}
+          className="hover:bg-gray-100"
+          aria-label="zoom out"
+        >
+          <UpRightArrow w={24} h={24} />
+        </IconButton>
+      </div>
+    </div>
+  );
+};
+
+export default ZoomControls;

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -211,3 +211,21 @@ export const ExternalLink: FC<IconProps> = ({ w, h }) => (
     />
   </svg>
 );
+
+export const MagnifyingGlassMinus: FC<IconProps> = ({ w, h }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={w}
+    height={h}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    <line x1="8" y1="11" x2="14" y2="11" />
+  </svg>
+);


### PR DESCRIPTION
## Description
- Prevented zooming through all means
- Replaced with buttons to zoom in/out, located right on the top left of the screen (minus sidebar)
- Restructured layers such that when a state/county is selected, only the state's counties are shown.  

## Related Issue
Closes #89 
Closes #90 

## Motivation and Context
This was needed to make usability of the map better, such that it is easier on the eyes, and people would be able to zoom in-and-out using buttons instead of the scroll wheel. Overall, we needed to reduce the clutter of counties, which was done here.

## How Has This Been Tested?
- Clicked around states/counties, with back button
- Clicked adjacent states from both county to state and state to state
- Clicked zoom back button

## Screenshots (if appropriate):
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/876d34db-55d8-408c-bc41-70e1252ab345" />
